### PR TITLE
Set Smooth CPU Priority for Meteo-Qt

### DIFF
--- a/bin/meteo-qt
+++ b/bin/meteo-qt
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
 if __name__ == '__main__':
+    import sys
+    import signal
+    sys.dont_write_bytecode = True
+    signal.signal(signal.SIGINT, signal.SIG_DFL)  # Makes CTRL+C work.
     from meteo_qt import meteo_qt
     meteo_qt.main()

--- a/bin/meteo-qt
+++ b/bin/meteo-qt
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
 if __name__ == '__main__':
-    import sys
-    import signal
-    sys.dont_write_bytecode = True
-    signal.signal(signal.SIGINT, signal.SIG_DFL)  # Makes CTRL+C work.
     from meteo_qt import meteo_qt
     meteo_qt.main()

--- a/meteo_qt/meteo_qt.py
+++ b/meteo_qt/meteo_qt.py
@@ -10,6 +10,7 @@ import logging.handlers
 import os
 import platform
 import re
+import signal
 import sys
 import urllib.request
 from functools import partial
@@ -41,7 +42,11 @@ except:
     from meteo_qt import about_dlg
 
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"
+
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)  # Makes CTRL+C work again on PyQt
+os.nice(19)  # Smooth CPU priority, just like Linux "nice" command.
 
 
 class SystemTrayIcon(QMainWindow):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# python3 setup.py bdist_egg bdist_wheel --universal sdist --formats=bztar,gztar,zip upload
 
 
 import glob
@@ -16,7 +17,7 @@ class BuildQm(build):
 
 setup(
     name='meteo_qt',
-    version='0.9.5',
+    version='0.9.6',
     description='A system tray application for the weather status',
     author='Dimitrios Glentadakis',
     author_email='dglent@free.fr',


### PR DESCRIPTION
- Set Smooth CPU Priority for Meteo-Qt.
- Makes `CTRL + C` work again on PyQt _(eg. when run from Terminal)_
- Bump Version.
