### PR TITLE
Fix for installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyqt6
-qt6-tools
 lxml
 sip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pyqt6
 lxml
-sip

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ class BuildQm(build):
             pyproject_files = ["meteo_qt/" + py for py in re.findall(r"([a-zA-Z0-9_/]+\.py)", content)]
             return pyproject_files
 
-    subprocess.run(["pylupdate6"] + extract_py_sources() + ["-ts", "translations/meteo-qt_en.ts"])
-    subprocess.run(subprocess.run(["lrelease-pro-qt6", "meteo_qt/meteo_qt.pro"]))
+    subprocess.run(["pylupdate6"] + extract_py_sources() + ["-ts", "meteo_qt/translations/meteo-qt_en.ts"])
+    subprocess.run(["lrelease-pro-qt6", "meteo_qt/meteo_qt.pro"])
 
 
 PROJECT_PATH = Path(__file__).parent


### PR DESCRIPTION
File `translations/meteo-qt_en.ts` should be installed in `meteo_qt/`
There is also a syntax issue in command `lrelease-pro-qt6`
I suggest also to remove these requirements:
- `qt6-tools` as it is only build requirement
- `sip` as it should be pulled if needed by other packages